### PR TITLE
Fix: Set 'centro' subscriber status to 'pendiente'

### DIFF
--- a/src/main/java/controller/AltaSuscriptor.java
+++ b/src/main/java/controller/AltaSuscriptor.java
@@ -116,7 +116,7 @@ public class AltaSuscriptor extends HttpServlet {
 	    // Crear al responsable como suscriptor
 	    Suscriptor s = new Suscriptor();
 	    s.setUsername(responsable);
-	    s.setEstado("estado");
+	    s.setEstado("pendiente");
 	    s.setFechaAlta(new Date(System.currentTimeMillis()));
 	    s.setTipo("responsable");
 	    s.setPassword(password);


### PR DESCRIPTION
When a 'centro' type subscriber is registered via the AltaSuscriptor servlet, its 'estado' (status) is now correctly set to 'pendiente'.

Previously, the status was incorrectly being set to a default 'estado' value. This change ensures that new center registrations are correctly flagged as pending, presumably for an approval process.